### PR TITLE
Add some GitHub Action

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -137,9 +137,10 @@ jobs:
         run: |
           podman images
 
-      # Just make sure that we can do this
+      # Make sure that we can run "podman-compose up" without errors.
       - name: Run podman-compose up
         run: podman-compose up --detach
 
+      # Make sure that we can run "podman-compose down" without errors.        
       - name: Run podman-compose down
         run: podman-compose down

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Print versions
         run: |
-          echo "====== Running: podman version ====="=
+          echo "====== Running: podman version ======"
           podman version
 
       - name: Build Debian base image

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Install podman [Ubuntu]
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt install podman
+          sudo apt install podman podman-compose
 
       - name: Install podman [macOS]
         if: matrix.os == 'macos-latest'
         run: |
-          brew install podman
+          brew install podman podman-compose
 
       # - name: Install podman-compose
       #   run: |

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Install podman [Ubuntu]
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt install podman podman-compose
+          sudo apt install podman
 
       - name: Install podman [macOS]
         if: matrix.os == 'macos-latest'
         run: |
-          brew install podman podman-compose
+          brew install podman
 
       # - name: Install podman-compose
       #   run: |

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -137,9 +137,9 @@ jobs:
         run: |
           podman images
 
-      # Just make sure that we can do this    
-      - name: Run podman-compose up/down
-        run: |
-          podman-compose up --detach
-          podman-compose down
+      # Just make sure that we can do this
+      - name: Run podman-compose up
+        run: podman-compose up --detach
 
+      - name: Run podman-compose down
+        run: podman-compose down

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -56,10 +56,10 @@ jobs:
         run: |
           brew install podman
 
-      # - name: Install podman-compose
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     python -m pip install podman-compose
+      - name: Install podman-compose
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install podman-compose
 
       - name: Print podman system connection
         run: |

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  build-images:
 
     runs-on:
       - ${{ matrix.os }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -48,13 +48,11 @@ jobs:
 
       - name: Install podman [Ubuntu]
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt install podman
+        run: sudo apt install podman
 
       - name: Install podman [macOS]
         if: matrix.os == 'macos-latest'
-        run: |
-          brew install podman
+        run: brew install podman
 
       - name: Install podman-compose
         run: |
@@ -62,8 +60,7 @@ jobs:
           python3 -m pip install podman-compose
 
       - name: Print podman system connection
-        run: |
-          podman system connection list
+        run: podman system connection list
 
       - name: Set up podman virtual machine [macOS]
         if: matrix.os == 'macos-latest'
@@ -81,8 +78,7 @@ jobs:
           podman system connection list
 
       - name: Print podman info
-        run: |
-          podman info --debug
+        run: podman info --debug
 
       - name: Print versions
         run: |
@@ -134,8 +130,7 @@ jobs:
           podman build -f ./container-app/Dockerfile -t sdx_api .
 
       - name: List images
-        run: |
-          podman images
+        run: podman images
 
       # Make sure that we can run "podman-compose up" without errors.
       - name: Run podman-compose up

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,141 @@
+name: Build container images
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on:
+      - ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.9"
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      # See https://github.com/marketplace/actions/setup-python
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # See https://github.com/marketplace/actions/cache
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Set up pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install podman [Ubuntu]
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt install podman
+
+      - name: Install podman [macOS]
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install podman
+
+      - name: Install podman-compose
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install podman-compose
+
+      - name: Print podman system connection
+        run: |
+          podman system connection list
+
+      - name: Set up podman virtual machine [macOS]
+        if: matrix.os == 'macos-latest'
+        run: |
+          echo "====== Running: podman machine init ======"
+          podman machine init
+
+          echo "====== Running: podman machine start ======"
+          podman machine start
+
+          echo "====== Running: podman machine list ======"
+          podman machine list
+
+          echo "====== Running: podman system connection list ======"
+          podman system connection list
+
+      - name: Print podman info
+        run: |
+          podman info --debug
+          
+      - name: Print versions
+        run: |
+          echo "====== Running: podman version ====="=
+          podman version
+          echo "====== Running: podman-compose version ======"
+          podman-compose version
+
+      - name: Build Debian base image
+        run: |
+          echo "Running: podman build -f ./os_base/debian_base/Dockerfile -t debian_base ."
+          podman build -f ./os_base/debian_base/Dockerfile -t debian_base .
+
+      - name: Build Ubuntu base image
+        run: |
+          echo "Running: podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base ."
+          podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base .
+
+      - name: Build mininet image
+        run: |
+          echo "Running: podman build -f ./container-mininet/Dockerfile -t mininet ."
+          podman build -f ./container-mininet/Dockerfile -t mininet .
+
+      - name: Build amlight image
+        run: |
+          echo "Running: podman build -f ./container-amlight/Dockerfile -t amlight ."
+          podman build -f ./container-amlight/Dockerfile -t amlight .
+
+      - name: Build sax image
+        run: |
+          echo "Running: podman build -f ./container-sax/Dockerfile -t sax ."
+          podman build -f ./container-sax/Dockerfile -t sax .
+
+      - name: Build tenet image
+        run: |
+          echo "Running: podman build -f ./container-tenet/Dockerfile -t tenet ."
+          podman build -f ./container-tenet/Dockerfile -t tenet .
+
+      - name: Build MongoDB image
+        run: |
+          echo "Running: podman build -f ./container-mongo/Dockerfile -t mongo_db ."
+          podman build -f ./container-mongo/Dockerfile -t mongo_db .
+
+      # - name: Build sdx_lc image
+      #   run: |
+      #     # podman build -f ./container-sdx-lc/Dockerfile -t sdx_lc .
+
+      - name: Build sdx_api image
+        run: |
+          echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
+          podman build -f ./container-app/Dockerfile -t sdx_api .
+
+      # TODO: figure out a way to invoke this in CI.    
+      # - name: Run podman-compose up
+      #   run: |
+      #     podman-compose up

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -56,10 +56,10 @@ jobs:
         run: |
           brew install podman
 
-      - name: Install podman-compose
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install podman-compose
+      # - name: Install podman-compose
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     python -m pip install podman-compose
 
       - name: Print podman system connection
         run: |
@@ -88,8 +88,6 @@ jobs:
         run: |
           echo "====== Running: podman version ====="=
           podman version
-          echo "====== Running: podman-compose version ======"
-          podman-compose version
 
       - name: Build Debian base image
         run: |
@@ -135,7 +133,3 @@ jobs:
           echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
           podman build -f ./container-app/Dockerfile -t sdx_api .
 
-      # TODO: figure out a way to invoke this in CI.    
-      # - name: Run podman-compose up
-      #   run: |
-      #     podman-compose up

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Print podman info
         run: |
           podman info --debug
-          
+
       - name: Print versions
         run: |
           echo "====== Running: podman version ====="=
@@ -133,3 +133,7 @@ jobs:
           echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
           podman build -f ./container-app/Dockerfile -t sdx_api .
 
+
+      - name: List images
+        run: |
+          podman images

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -133,7 +133,13 @@ jobs:
           echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
           podman build -f ./container-app/Dockerfile -t sdx_api .
 
-
       - name: List images
         run: |
           podman images
+
+      # Just make sure that we can do this    
+      - name: Run podman-compose up/down
+        run: |
+          podman-compose up --detach
+          podman-compose down
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,9 @@ jobs:
           echo "Running: podman build -f ./os_base/debian_base/Dockerfile -t debian_base ."
           podman build -f ./os_base/debian_base/Dockerfile -t debian_base .
 
+          echo "Running: podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base ."
+          podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base .
+
           echo "Running: podman build -f ./container-amlight/Dockerfile -t amlight ."
           podman build -f ./container-amlight/Dockerfile -t amlight .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build mininet image
         run: |
-          echo: "Running: podman build -f ./container-mininet/Dockerfile -t mininet ."
+          echo "Running: podman build -f ./container-mininet/Dockerfile -t mininet ."
           podman build -f ./container-mininet/Dockerfile -t mininet .
 
       - name: Build amlight image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Run tests
 
 on:
   push:
@@ -19,124 +19,43 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
         python-version:
           - "3.9"
 
     steps:
-      # - name: Check out code
-      #   uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@v3
 
-      # # See https://github.com/marketplace/actions/setup-python
-      # - name: Set up Python ${{ matrix.python-version }}
-      #   uses: actions/setup-python@v3
-      #   with:
-      #     python-version: ${{ matrix.python-version }}
+      # See https://github.com/marketplace/actions/setup-python
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
 
-      # # See https://github.com/marketplace/actions/cache
-      # - name: Get pip cache dir
-      #   id: pip-cache
-      #   run: |
-      #     echo "::set-output name=dir::$(pip cache dir)"
+      # See https://github.com/marketplace/actions/cache
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
 
-      # - name: Set up pip cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ${{ steps.pip-cache.outputs.dir }}
-      #     key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-pip-
+      - name: Set up pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-      # - name: Install podman [Ubuntu]
-      #   if: matrix.os == 'ubuntu-latest'
-      #   run: |
-      #     sudo apt install podman
+      - name: Install Python packages
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
 
-      # - name: Install podman [macOS]
-      #   if: matrix.os == 'macos-latest'
-      #   run: |
-      #     brew install podman
-
-      # - name: Install podman-compose
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     python -m pip install podman-compose
-
-      # - name: Print podman system connection
-      #   run: |
-      #     podman system connection list
-
-      # - name: Set up podman virtual machine [macOS]
-      #   if: matrix.os == 'macos-latest'
-      #   run: |
-      #     echo "====== Running: podman machine init ======"
-      #     podman machine init
-
-      #     echo "====== Running: podman machine start ======"
-      #     podman machine start
-
-      #     echo "====== Running: podman machine list ======"
-      #     podman machine list
-
-      #     echo "====== Running: podman system connection list ======"
-      #     podman system connection list
-
-      # - name: Print podman info
-      #   run: |
-      #     podman info --debug
-          
-      # - name: Print versions
-      #   run: |
-      #     echo "====== Running: podman version ====="=
-      #     podman version
-      #     echo "====== Running: podman-compose version ======"
-      #     podman-compose version
-
-      # - name: Build Debian base image
-      #   run: |
-      #     echo "Running: podman build -f ./os_base/debian_base/Dockerfile -t debian_base ."
-      #     podman build -f ./os_base/debian_base/Dockerfile -t debian_base .
-
-      # - name: Build Ubuntu base image
-      #   run: |
-      #     echo "Running: podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base ."
-      #     podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base .
-
-      # - name: Build mininet image
-      #   run: |
-      #     echo "Running: podman build -f ./container-mininet/Dockerfile -t mininet ."
-      #     podman build -f ./container-mininet/Dockerfile -t mininet .
-
-      # - name: Build amlight image
-      #   run: |
-      #     echo "Running: podman build -f ./container-amlight/Dockerfile -t amlight ."
-      #     podman build -f ./container-amlight/Dockerfile -t amlight .
-
-      # - name: Build sax image
-      #   run: |
-      #     echo "Running: podman build -f ./container-sax/Dockerfile -t sax ."
-      #     podman build -f ./container-sax/Dockerfile -t sax .
-
-      # - name: Build tenet image
-      #   run: |
-      #     echo "Running: podman build -f ./container-tenet/Dockerfile -t tenet ."
-      #     podman build -f ./container-tenet/Dockerfile -t tenet .
-
-      # - name: Build MongoDB image
-      #   run: |
-      #     echo "Running: podman build -f ./container-mongo/Dockerfile -t mongo_db ."
-      #     podman build -f ./container-mongo/Dockerfile -t mongo_db .
-
-      # # - name: Build sdx_lc image
-      # #   run: |
-      # #     # podman build -f ./container-sdx-lc/Dockerfile -t sdx_lc .
-
-      # - name: Build sdx_api image
-      #   run: |
-      #     echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
-      #     podman build -f ./container-app/Dockerfile -t sdx_api .
-
-      # # TODO: figure out a way to invoke this in CI.    
-      # # - name: Run podman-compose up
-      # #   run: |
-      # #     podman-compose up
-
+      - name: Run tests
+        # TODO: Here we pretend that things are fine even though
+        # pytest will fail.  That is because we haven't implemented
+        # any actual tests yet.
+        continue-on-error: true
+        run: |
+          python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,9 @@ jobs:
           echo "====== Running podman machine init ======"
           podman machine init
 
+          echo "====== Running podman machine start ======"
+          podman machine start
+
           echo "====== Running podman machine list ======"
           podman machine list
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install podman [Ubuntu]
         if: matrix.os == 'ubuntu-latest'
         run: |
-          apt install podman
+          sudo apt install podman
 
       - name: Install podmman [macOS]
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,16 +69,13 @@ jobs:
       - name: Set up podman virtual machine [macOS]
         if: matrix.os == 'macos-latest'
         run: |
-          echo "====== Running `podman machine init` ======"
+          echo "====== Running podman machine init ======"
           podman machine init
 
-          # echo "====== Running `podman machine start` ======"
-          # podman machine start
-
-          echo "====== Running `podman machine list` ======"
+          echo "====== Running podman machine list ======"
           podman machine list
 
-          echo "====== Running `podman system connection list` ======"
+          echo "====== Running podman system connection list ======"
           podman system connection list
 
       - name: Print podman info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,9 @@ jobs:
           echo "Running: podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base ."
           podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base .
 
+          echo: "Running: podman build -f ./container-mininet/Dockerfile -t mininet ."
+          podman build -f ./container-mininet/Dockerfile -t mininet .
+
           echo "Running: podman build -f ./container-amlight/Dockerfile -t amlight ."
           podman build -f ./container-amlight/Dockerfile -t amlight .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install podman-compose
 
+      - name: Print podman system connection
+        run: |
+          podman system connection list
+
       - name: Print podman info
         run: |
           podman info --debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,16 +69,16 @@ jobs:
       - name: Set up podman virtual machine [macOS]
         if: matrix.os == 'macos-latest'
         run: |
-          echo "====== Running podman machine init ======"
+          echo "====== Running: podman machine init ======"
           podman machine init
 
-          echo "====== Running podman machine start ======"
+          echo "====== Running: podman machine start ======"
           podman machine start
 
-          echo "====== Running podman machine list ======"
+          echo "====== Running: podman machine list ======"
           podman machine list
 
-          echo "====== Running podman system connection list ======"
+          echo "====== Running: podman system connection list ======"
           podman system connection list
 
       - name: Print podman info
@@ -87,6 +87,8 @@ jobs:
           
       - name: Print versions
         run: |
+          echo "====== Running: podman version ====="=
           podman version
+          echo "====== Running: podman-compose version ======"
           podman-compose version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,25 @@ jobs:
           echo "====== Running: podman-compose version ======"
           podman-compose version
 
+      - name: Build container images
+        run: |
+          echo "Running: podman build -f ./container-amlight/Dockerfile -t amlight ."
+          podman build -f ./container-amlight/Dockerfile -t amlight .
+
+          echo "Running: podman build -f ./container-sax/Dockerfile -t sax ."
+          podman build -f ./container-sax/Dockerfile -t sax .
+
+          echo "Running: podman build -f ./container-tenet/Dockerfile -t tenet ."
+          podman build -f ./container-tenet/Dockerfile -t tenet .
+
+          echo "Running: podman build -f ./container-mongo/Dockerfile -t mongo_db ."
+          podman build -f ./container-mongo/Dockerfile -t mongo_db .
+
+          # podman build -f ./container-sdx-lc/Dockerfile -t sdx_lc .
+
+          echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
+          podman build -f ./container-app/Dockerfile -t sdx_api .
+
       - name: Run podman-compose up
         run: |
           podman-compose up

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python-version:
-          - "3.8"
           - "3.9"
-          - "3.10"
 
     steps:
       - name: Check out code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+name: Test
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on:
+      - ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      # See https://github.com/marketplace/actions/setup-python
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # See https://github.com/marketplace/actions/cache
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Set up pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install podman [Ubuntu]
+        if: matrix.os == 'ubuntu-latest'
+        name: |
+          apt install podman
+
+      - name: Install podmman [macOS]
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install podman
+
+      - name: Install podman-compose
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install podman-compose
+
+      - name: Print versions
+        run: |
+          podman version
+          podman-compose version
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install podman [Ubuntu]
         if: matrix.os == 'ubuntu-latest'
-        name: |
+        run: |
           apt install podman
 
       - name: Install podmman [macOS]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,21 @@ jobs:
         run: |
           podman system connection list
 
+      - name: Set up podman virtual machine [macOS]
+        if: matrix.os == 'macos-latest'
+        run: |
+          echo "====== Running `podman machine init` ======"
+          podman machine init
+
+          echo "====== Running `podman machine start` ======"
+          podman machine start
+
+          echo "====== Running `podman machine list` ======"
+          podman machine list
+
+          echo "====== Running `podman system connection list` ======"
+          podman system connection list
+
       - name: Print podman info
         run: |
           podman info --debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,31 +91,46 @@ jobs:
           echo "====== Running: podman-compose version ======"
           podman-compose version
 
-      - name: Build container images
+      - name: Build Debian base image
         run: |
           echo "Running: podman build -f ./os_base/debian_base/Dockerfile -t debian_base ."
           podman build -f ./os_base/debian_base/Dockerfile -t debian_base .
 
+      - name: Build Ubuntu base image
+        run: |
           echo "Running: podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base ."
           podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base .
 
+      - name: Build mininet image
+        run: |
           echo: "Running: podman build -f ./container-mininet/Dockerfile -t mininet ."
           podman build -f ./container-mininet/Dockerfile -t mininet .
 
+      - name: Build amlight image
+        run: |
           echo "Running: podman build -f ./container-amlight/Dockerfile -t amlight ."
           podman build -f ./container-amlight/Dockerfile -t amlight .
 
+      - name: Build sax image
+        run: |
           echo "Running: podman build -f ./container-sax/Dockerfile -t sax ."
           podman build -f ./container-sax/Dockerfile -t sax .
 
+      - name: Build tenet image
+        run: |
           echo "Running: podman build -f ./container-tenet/Dockerfile -t tenet ."
           podman build -f ./container-tenet/Dockerfile -t tenet .
 
+      - name: Build MongoDB image
+        run: |
           echo "Running: podman build -f ./container-mongo/Dockerfile -t mongo_db ."
           podman build -f ./container-mongo/Dockerfile -t mongo_db .
 
-          # podman build -f ./container-sdx-lc/Dockerfile -t sdx_lc .
+      # - name: Build sdx_lc image
+      #   run: |
+      #     # podman build -f ./container-sdx-lc/Dockerfile -t sdx_lc .
 
+      - name: Build sdx_api image
           echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
           podman build -f ./container-app/Dockerfile -t sdx_api .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
         python-version:
           - "3.9"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,3 +91,6 @@ jobs:
           echo "====== Running: podman-compose version ======"
           podman-compose version
 
+      - name: Run podman-compose up
+        run: |
+          podman-compose up

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,7 @@ jobs:
       #     # podman build -f ./container-sdx-lc/Dockerfile -t sdx_lc .
 
       - name: Build sdx_api image
+        run: |
           echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
           podman build -f ./container-app/Dockerfile -t sdx_api .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,8 @@ jobs:
           echo "====== Running `podman machine init` ======"
           podman machine init
 
-          echo "====== Running `podman machine start` ======"
-          podman machine start
+          # echo "====== Running `podman machine start` ======"
+          # podman machine start
 
           echo "====== Running `podman machine list` ======"
           podman machine list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,9 @@ jobs:
 
       - name: Build container images
         run: |
+          echo "Running: podman build -f ./os_base/debian_base/Dockerfile -t debian_base ."
+          podman build -f ./os_base/debian_base/Dockerfile -t debian_base .
+
           echo "Running: podman build -f ./container-amlight/Dockerfile -t amlight ."
           podman build -f ./container-amlight/Dockerfile -t amlight .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           sudo apt install podman
 
-      - name: Install podmman [macOS]
+      - name: Install podman [macOS]
         if: matrix.os == 'macos-latest'
         run: |
           brew install podman

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,7 @@ jobs:
           echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
           podman build -f ./container-app/Dockerfile -t sdx_api .
 
-      - name: Run podman-compose up
-        run: |
-          podman-compose up
+      # TODO: figure out a way to invoke this in CI.    
+      # - name: Run podman-compose up
+      #   run: |
+      #     podman-compose up

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,119 +23,120 @@ jobs:
           - "3.9"
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
+      # - name: Check out code
+      #   uses: actions/checkout@v3
 
-      # See https://github.com/marketplace/actions/setup-python
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
+      # # See https://github.com/marketplace/actions/setup-python
+      # - name: Set up Python ${{ matrix.python-version }}
+      #   uses: actions/setup-python@v3
+      #   with:
+      #     python-version: ${{ matrix.python-version }}
 
-      # See https://github.com/marketplace/actions/cache
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+      # # See https://github.com/marketplace/actions/cache
+      # - name: Get pip cache dir
+      #   id: pip-cache
+      #   run: |
+      #     echo "::set-output name=dir::$(pip cache dir)"
 
-      - name: Set up pip cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+      # - name: Set up pip cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ${{ steps.pip-cache.outputs.dir }}
+      #     key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-pip-
 
-      - name: Install podman [Ubuntu]
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt install podman
+      # - name: Install podman [Ubuntu]
+      #   if: matrix.os == 'ubuntu-latest'
+      #   run: |
+      #     sudo apt install podman
 
-      - name: Install podman [macOS]
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install podman
+      # - name: Install podman [macOS]
+      #   if: matrix.os == 'macos-latest'
+      #   run: |
+      #     brew install podman
 
-      - name: Install podman-compose
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install podman-compose
+      # - name: Install podman-compose
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     python -m pip install podman-compose
 
-      - name: Print podman system connection
-        run: |
-          podman system connection list
+      # - name: Print podman system connection
+      #   run: |
+      #     podman system connection list
 
-      - name: Set up podman virtual machine [macOS]
-        if: matrix.os == 'macos-latest'
-        run: |
-          echo "====== Running: podman machine init ======"
-          podman machine init
+      # - name: Set up podman virtual machine [macOS]
+      #   if: matrix.os == 'macos-latest'
+      #   run: |
+      #     echo "====== Running: podman machine init ======"
+      #     podman machine init
 
-          echo "====== Running: podman machine start ======"
-          podman machine start
+      #     echo "====== Running: podman machine start ======"
+      #     podman machine start
 
-          echo "====== Running: podman machine list ======"
-          podman machine list
+      #     echo "====== Running: podman machine list ======"
+      #     podman machine list
 
-          echo "====== Running: podman system connection list ======"
-          podman system connection list
+      #     echo "====== Running: podman system connection list ======"
+      #     podman system connection list
 
-      - name: Print podman info
-        run: |
-          podman info --debug
+      # - name: Print podman info
+      #   run: |
+      #     podman info --debug
           
-      - name: Print versions
-        run: |
-          echo "====== Running: podman version ====="=
-          podman version
-          echo "====== Running: podman-compose version ======"
-          podman-compose version
-
-      - name: Build Debian base image
-        run: |
-          echo "Running: podman build -f ./os_base/debian_base/Dockerfile -t debian_base ."
-          podman build -f ./os_base/debian_base/Dockerfile -t debian_base .
-
-      - name: Build Ubuntu base image
-        run: |
-          echo "Running: podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base ."
-          podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base .
-
-      - name: Build mininet image
-        run: |
-          echo "Running: podman build -f ./container-mininet/Dockerfile -t mininet ."
-          podman build -f ./container-mininet/Dockerfile -t mininet .
-
-      - name: Build amlight image
-        run: |
-          echo "Running: podman build -f ./container-amlight/Dockerfile -t amlight ."
-          podman build -f ./container-amlight/Dockerfile -t amlight .
-
-      - name: Build sax image
-        run: |
-          echo "Running: podman build -f ./container-sax/Dockerfile -t sax ."
-          podman build -f ./container-sax/Dockerfile -t sax .
-
-      - name: Build tenet image
-        run: |
-          echo "Running: podman build -f ./container-tenet/Dockerfile -t tenet ."
-          podman build -f ./container-tenet/Dockerfile -t tenet .
-
-      - name: Build MongoDB image
-        run: |
-          echo "Running: podman build -f ./container-mongo/Dockerfile -t mongo_db ."
-          podman build -f ./container-mongo/Dockerfile -t mongo_db .
-
-      # - name: Build sdx_lc image
+      # - name: Print versions
       #   run: |
-      #     # podman build -f ./container-sdx-lc/Dockerfile -t sdx_lc .
+      #     echo "====== Running: podman version ====="=
+      #     podman version
+      #     echo "====== Running: podman-compose version ======"
+      #     podman-compose version
 
-      - name: Build sdx_api image
-        run: |
-          echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
-          podman build -f ./container-app/Dockerfile -t sdx_api .
-
-      # TODO: figure out a way to invoke this in CI.    
-      # - name: Run podman-compose up
+      # - name: Build Debian base image
       #   run: |
-      #     podman-compose up
+      #     echo "Running: podman build -f ./os_base/debian_base/Dockerfile -t debian_base ."
+      #     podman build -f ./os_base/debian_base/Dockerfile -t debian_base .
+
+      # - name: Build Ubuntu base image
+      #   run: |
+      #     echo "Running: podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base ."
+      #     podman build -f ./os_base/ubuntu_base/Dockerfile -t ubuntu_base .
+
+      # - name: Build mininet image
+      #   run: |
+      #     echo "Running: podman build -f ./container-mininet/Dockerfile -t mininet ."
+      #     podman build -f ./container-mininet/Dockerfile -t mininet .
+
+      # - name: Build amlight image
+      #   run: |
+      #     echo "Running: podman build -f ./container-amlight/Dockerfile -t amlight ."
+      #     podman build -f ./container-amlight/Dockerfile -t amlight .
+
+      # - name: Build sax image
+      #   run: |
+      #     echo "Running: podman build -f ./container-sax/Dockerfile -t sax ."
+      #     podman build -f ./container-sax/Dockerfile -t sax .
+
+      # - name: Build tenet image
+      #   run: |
+      #     echo "Running: podman build -f ./container-tenet/Dockerfile -t tenet ."
+      #     podman build -f ./container-tenet/Dockerfile -t tenet .
+
+      # - name: Build MongoDB image
+      #   run: |
+      #     echo "Running: podman build -f ./container-mongo/Dockerfile -t mongo_db ."
+      #     podman build -f ./container-mongo/Dockerfile -t mongo_db .
+
+      # # - name: Build sdx_lc image
+      # #   run: |
+      # #     # podman build -f ./container-sdx-lc/Dockerfile -t sdx_lc .
+
+      # - name: Build sdx_api image
+      #   run: |
+      #     echo "Running: podman build -f ./container-app/Dockerfile -t sdx_api ."
+      #     podman build -f ./container-app/Dockerfile -t sdx_api .
+
+      # # TODO: figure out a way to invoke this in CI.    
+      # # - name: Run podman-compose up
+      # #   run: |
+      # #     podman-compose up
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install podman-compose
 
+      - name: Print podman info
+        run: |
+          podman info --debug
+          
       - name: Print versions
         run: |
           podman version


### PR DESCRIPTION
Addressing #2. This PR adds two workflows: one for building some container images (thus ensuring that our ), and another for running tests with pytest.  Some example of this at work are [here](https://github.com/sajith/sdx-continuous-development/actions).

Of course, there are no real tests yet, so the "Run tests" workflow isn't exactly useful at the moment.  It is set to ignore test failures (with `continue-on-error: true` flag) and pretend that things are fine.  We can change that when we have some real tests.