### PR TITLE
Fix: adjustments on the setup to get working environment

### DIFF
--- a/0_multipass_setup.sh
+++ b/0_multipass_setup.sh
@@ -4,8 +4,9 @@ multipass set client.primary-name=sdx
 multipass list
 multipass info sdx
 echo "### Ubuntu update ###"
+multipass exec sdx -- bash -c 'echo "\$nrconf{restart} = \"l\"" | sudo tee -a /etc/needrestart/needrestart.conf'
 multipass exec sdx -- bash -c "sudo apt-get update --assume-yes"
-multipass exec sdx sudo apt-get -y upgrade
+multipass exec sdx -- bash -c "sudo apt-get -y upgrade"
 echo "### dependencies install ###"
 multipass exec sdx -- bash -c "sudo apt-get install --assume-yes --no-install-recommends \
                 apt-transport-https build-essential ca-certificates curl dirmngr dpkg-dev docker gcc \
@@ -13,7 +14,7 @@ multipass exec sdx -- bash -c "sudo apt-get install --assume-yes --no-install-re
 		liblzma-dev libncurses5-dev libgdbm-dev libnss3-dev libreadline-dev \
 		libsqlite3-dev libssl-dev lsb-release lsof make mininet net-tools netbase netcat \
 		openvswitch-switch-dpdk podman software-properties-common uuid-dev wget \
-		xz-utils zlib1g-dev"
+		xz-utils zlib1g-dev jq"
 echo "### install python 3.9 ###"
 multipass exec sdx -- bash -c "sudo add-apt-repository -y ppa:deadsnakes/ppa"
 multipass exec sdx -- bash -c "sudo apt-get install --assume-yes python3.9"
@@ -24,7 +25,7 @@ echo "### docker install ###"
 multipass exec sdx -- bash -c "sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg"
 multipass exec sdx -- bash -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null'
 multipass exec sdx -- bash -c "sudo apt remove -y python3-apt"
-multipass exec sdx -- bash -c "sudo apt install python3-apt"
+multipass exec sdx -- bash -c "sudo apt install -y python3-apt"
 multipass exec sdx sudo apt-get update
 multipass exec sdx -- bash -c "sudo apt install docker-ce docker-ce-cli containerd.io -y"
 multipass exec sdx -- bash -c "sudo usermod -aG docker ubuntu"
@@ -34,7 +35,7 @@ multipass exec sdx -- bash -c "chmod +x ~/.docker/cli-plugins/docker-compose"
 #multipass exec sdx -- bash -c "sudo newgrp docker"
 multipass exec sdx -- bash -c "sudo pip install docker-compose"
 multipass exec sdx -- bash -c "sudo apt-get update"
-multipass exec sdx -- bash -c "sudo apt-get install docker-compose"
+multipass exec sdx -- bash -c "sudo apt-get install -y docker-compose"
 echo "### set mininet ###"
 multipass exec sdx -- bash -c "sudo mn --version"
 multipass exec sdx -- bash -c "sudo mn --switch ovsbr --test pingall"

--- a/data-plane/container-mininet/start_mininet.sh
+++ b/data-plane/container-mininet/start_mininet.sh
@@ -4,11 +4,8 @@
 service openvswitch-switch start
 ovs-vsctl set-manager ptcp:6640
 
-# Interactive
-bash
-
 # Stop (can ignore this line haha)
 # service openvswitch-switch stop
-python /link-hosts.py
+tmux new-sess -d -s mn python /link-hosts.py
 
-
+tail -f /dev/null

--- a/data-plane/docker-compose.yml
+++ b/data-plane/docker-compose.yml
@@ -109,6 +109,7 @@ services:
     volumes:
       - ./tests:/tests
       - ./scripts:/scripts
+      - ./etc/kytos:/etc/kytos
     environment:
       MONGO_USERNAME: amlight_user
       MONGO_PASSWORD: amlight_pwd
@@ -133,6 +134,7 @@ services:
     volumes:
       - ./tests:/tests
       - ./scripts:/scripts
+      - ./etc/kytos:/etc/kytos
     environment:
       MONGO_USERNAME: sax_user
       MONGO_PASSWORD: sax_pwd
@@ -157,6 +159,7 @@ services:
     volumes:
       - ./tests:/tests
       - ./scripts:/scripts
+      - ./etc/kytos:/etc/kytos
     environment:
       MONGO_USERNAME: tenet_user
       MONGO_PASSWORD: tenet_pwd

--- a/data-plane/etc/kytos/kytos.conf
+++ b/data-plane/etc/kytos/kytos.conf
@@ -1,0 +1,99 @@
+[daemon]
+
+# Full path of the working directory to which the process should change on
+# daemon start. Since a filesystem cannot be unmounted if a process has its
+# current working directory on that filesystem, this should either be left at
+# default or set to a directory that is a sensible home directory for the
+# daemon while it is running. Default is /var/lib/kytos.
+workdir = //var/lib/kytos
+
+# PID file to write. When the controller starts, it will save the his pid on
+# this file.
+pidfile = //var/run/kytos/kytosd.pid
+
+# This controller can be started in two modes: 'daemon' mode or 'interactive'
+# mode. On daemon mode, the process will detach from terminal when starts,
+# running in background. When running on 'interactive' mode, you will receive a
+# console right after the controller starts. Default is 'daemon' mode.
+daemon = True
+
+# Run the controller in debug mode or not. Default is False.
+debug = False
+
+# Logging config file. Please specify the full path of logging config file.
+logging = //etc/kytos/logging.ini
+
+# List of decorators to be applied to the Logger Class
+logger_decorators = ["kytos.core.logger_decorators.queue_decorator"]
+
+# The listen parameter tells kytos controller to accept incoming requests
+# only in the specified address. Default is 0.0.0.0.
+listen = 0.0.0.0
+
+# The port parameter tells kytos controller to accept and to send
+# openflow packets using TCP protocol. Default is 6653.
+port = 6653
+
+# Southbound protocol name of the TCP server. Don't use quotes in the string.
+protocol_name =
+
+# Switch connection timeout in seconds.
+connection_timeout = 130
+
+# The api_port parameter tells kytos controller to expose a port to accept
+# incoming requests and to send a response from kytos API REST.
+# Default is 8181.
+api_port = 8181
+
+# When a new entity (switch, interface or link) is created it is
+# administratively disabled by default. Change here to modify this behavior.
+# enable_entities_by_default = False
+
+# Where should the controller look for network apps ?
+# This directory has both core napps and user installed napps.
+napps = //var/lib/kytos/napps
+
+napps_repositories = [
+    "https://napps.kytos.io/repo/"
+    ]
+
+# Pre installed napps. List of Napps to be pre-installed and enabled.
+# Use double quotes in each NApp in the list, e.g., ["username/napp"].
+napps_pre_installed = []
+
+# VLAN pool settings
+#
+# The VLAN pool settings is a dictionary of datapath id, which contains
+# a dictionary of of_port numbers with the respective vlan pool range
+# for each port number. See the example below, which sets the vlan range
+# [1, 5, 6, 7, 8, 9] on port 1 and vlan range [3] on port 4 of a switch
+# that has a dpid '00:00:00:00:00:00:00:01'
+
+vlan_pool = {}
+# vlan_pool = {"00:00:00:00:00:00:00:01": {"1": [[1, 2], [5, 10]], "4": [[3, 4]]}}
+
+# The jwt_secret parameter is responsible for signing JSON Web Tokens.
+jwt_secret = 967e3d8723c641a48db959dd6ba30cb1
+
+# Maximum number of thread workers in a thread pool, if it's set as empty dict {} no thread pools will be used.
+# The following pools are available by default to be used in the listen_to decorator:
+# - sb: it's used automatically by kytos/of_core.* events, it's meant for southbound related messages
+# - app: it's meant for general NApps event, it's default pool if no other one has been specified
+# - db: it can be used by for higher priority db related tasks (need to be parametrized on decorator)
+thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512}
+
+# Time to expire authentication token in minutes
+token_expiration_minutes = 180
+
+# NApps database. Supported values: mongodb (don't use quotes in the string)
+database =
+
+# APM backend. Supported values: es (elasticsearch, don't use quotes in the string)
+apm =
+
+# Define URLs that will require authentication
+#
+# This must be a list of part of URLs. For example, if "kytos/mef_eline"
+# is in the list, then every URL containing "kytos/mef_eline" will match
+# it and, therefore, require authentication.
+# authenticate_urls = ["kytos/mef_eline", "kytos/pathfinder"]

--- a/data-plane/etc/kytos/logging.ini
+++ b/data-plane/etc/kytos/logging.ini
@@ -1,0 +1,53 @@
+[formatters]
+keys: console,syslog,file
+
+[handlers]
+keys: console,syslog,file
+
+[loggers]
+keys: root,kytos,api_server,socket
+
+[formatter_syslog]
+format: %(name)s:%(levelname)s %(module)s:%(lineno)d:  %(message)s
+
+[formatter_console]
+format: %(asctime)s - %(levelname)s [%(name)s] (%(threadName)s) %(message)s
+
+[formatter_file]
+format: %(asctime)s - %(levelname)s [%(name)s] [%(filename)s:%(lineno)d:%(funcName)s] (%(threadName)s) %(message)s
+
+[handler_console]
+class: StreamHandler
+args:[sys.stdout]
+formatter: console
+
+[handler_syslog]
+class: handlers.SysLogHandler
+args: []
+formatter: syslog
+
+[handler_file]
+class: handlers.RotatingFileHandler
+args:["/var/log/kytos.log", "a", 10*1024*1024, 5]
+formatter: file
+level: INFO
+
+[logger_root]
+level: INFO
+handlers: file
+
+[logger_kytos]
+level: INFO
+qualname: kytos
+handlers: file
+propagate=0
+
+[logger_api_server]
+level: INFO
+qualname: werkzeug
+handlers: file
+
+[logger_socket]
+level: ERROR
+qualname: engineio
+handlers: file

--- a/data-plane/os_base/debian_base/Dockerfile
+++ b/data-plane/os_base/debian_base/Dockerfile
@@ -27,6 +27,8 @@ ARG branch_coloring=master
 ARG branch_sdntrace=master
 ARG branch_flow_stats=master
 ARG branch_sdntrace_cp=master
+# USAGE: ... --build-arg release_ui=download/2022.2.0 ...
+ARG release_ui=latest/download
 
 
 # http://bugs.python.org/issue19846
@@ -97,7 +99,10 @@ RUN python3 -m pip install -e git+https://github.com/kytos-ng/of_core@${branch_o
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace@${branch_sdntrace}#egg=amlight-sdntrace \
  && python3 -m pip install -e git+https://github.com/kytos-ng/flow_stats@${branch_flow_stats}#egg=amlight-flow_stats \
  && python3 -m pip install -e git+https://github.com/kytos-ng/sdntrace_cp@${branch_sdntrace_cp}#egg=amlight-sdntrace_cp \
- && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline
+ && python3 -m pip install -e git+https://github.com/kytos-ng/mef_eline@${branch_mef_eline}#egg=kytos-mef_eline \
+ && curl -L -o /tmp/latest.zip https://github.com/kytos-ng/ui/releases/${release_ui}/latest.zip \
+ && python3 -m zipfile -e /tmp/latest.zip  /usr/local/lib/python3.9/dist-packages/kytos/web-ui \
+ && rm -f /tmp/latest.zip
 
 # end-to-end python related dependencies
 # pymongo and requests resolve to the same version on kytos and NApps

--- a/data-plane/os_base/ubuntu_base/Dockerfile
+++ b/data-plane/os_base/ubuntu_base/Dockerfile
@@ -14,4 +14,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netcat \
     openvswitch-switch \
     wget \
+    tmux \
  && rm -rf /var/lib/apt/lists/*

--- a/data-plane/scripts/amlight_kytos.sh
+++ b/data-plane/scripts/amlight_kytos.sh
@@ -14,4 +14,7 @@ while ! nc -z 192.168.0.8 27029; do
   sleep 1 # wait 1 second before check for mongo3t again
 done
 
-exec kytosd -l 192.168.0.2 -f --database mongodb
+tmux new-sess -d -s k1 kytosd -f --database mongodb
+
+touch /var/log/kytos.log
+tail -f /var/log/kytos.log

--- a/data-plane/scripts/curl/config_hosts_and_test.sh
+++ b/data-plane/scripts/curl/config_hosts_and_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# VLAN 107 - same VLAN
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip link add link h8-eth1 name vlan107 type vlan id 107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip link set up vlan107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip addr add 10.1.7.8/24 dev vlan107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip link add link h3-eth1 name vlan107 type vlan id 107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip link set up vlan107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip addr add 10.1.7.3/24 dev vlan107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ping -c4 10.1.7.8'
+
+# VLAN 201 - VLAN translation
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip link add link h8-eth1 name vlan201 type vlan id 201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip link set up vlan201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip addr add 10.2.1.8/24 dev vlan201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip link add link h3-eth1 name vlan201 type vlan id 201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip link set up vlan201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip addr add 10.2.1.3/24 dev vlan201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ping -c4 10.2.1.8'

--- a/data-plane/scripts/curl/create_evcs_inter_domain.sh
+++ b/data-plane/scripts/curl/create_evcs_inter_domain.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Creates a circuit between AmLight (h3) and TENET (h8) -- same VLAN all domains
+
+# Amlight domain
+curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc -d '{"name": "AMLIGHT_vlan_107_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:03:50"}, "uni_z": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:01:40"}}'
+
+# SAX domain
+curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8282/api/kytos/mef_eline/v2/evc -d '{"name": "SAX_vlan_107_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:04:40"}, "uni_z": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:05:41"}}'
+
+# TENET domain
+curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8383/api/kytos/mef_eline/v2/evc -d '{"name": "TENET_vlan_107_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:07:41"}, "uni_z": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:08:50"}}'

--- a/data-plane/scripts/curl/create_evcs_inter_domain_vlan_translation.sh
+++ b/data-plane/scripts/curl/create_evcs_inter_domain_vlan_translation.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Creates a circuit between AmLight (h3) and TENET (h8) -- using VLAN translation, i.e., endpoints will be VLAN 201, intermediate VLANs will be 202 and 203
+
+# Amlight domain
+curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc -d '{"name": "AMLIGHT_vlan_201_202_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 201, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:03:50"}, "uni_z": {"tag": {"value": 202, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:01:40"}}'
+
+# SAX domain
+curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8282/api/kytos/mef_eline/v2/evc -d '{"name": "SAX_vlan_202_203_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 202, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:04:40"}, "uni_z": {"tag": {"value": 203, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:05:41"}}'
+
+# TENET domain
+curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8383/api/kytos/mef_eline/v2/evc -d '{"name": "TENET_vlan_201_203_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 203, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:07:41"}, "uni_z": {"tag": {"value": 201, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:08:50"}}'

--- a/data-plane/scripts/curl/enable_all.sh
+++ b/data-plane/scripts/curl/enable_all.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+AMLIGHT=http://127.0.0.1:8181
+SAX=http://127.0.0.1:8282
+TENET=http://127.0.0.1:8383
+
+# Enable all switches
+for sw in $(curl -s $AMLIGHT/api/kytos/topology/v3/switches | jq -r '.switches[].id'); do curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/switches/$sw/enable; curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/interfaces/switch/$sw/enable; done
+for sw in $(curl -s $SAX/api/kytos/topology/v3/switches | jq -r '.switches[].id'); do curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/switches/$sw/enable; curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/interfaces/switch/$sw/enable; done
+for sw in $(curl -s $TENET/api/kytos/topology/v3/switches | jq -r '.switches[].id'); do curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/switches/$sw/enable; curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/interfaces/switch/$sw/enable; done
+
+# give a few seconds for link discovery (LLDP)
+sleep 10
+
+# enable all links
+for l in $(curl -s $AMLIGHT/api/kytos/topology/v3/links | jq -r '.links[].id'); do curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/links/$l/enable; done
+for l in $(curl -s $SAX/api/kytos/topology/v3/links | jq -r '.links[].id'); do curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/links/$l/enable; done
+for l in $(curl -s $TENET/api/kytos/topology/v3/links | jq -r '.links[].id'); do curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/links/$l/enable; done

--- a/data-plane/scripts/sax_kytos.sh
+++ b/data-plane/scripts/sax_kytos.sh
@@ -14,4 +14,7 @@ while ! nc -z 192.168.0.8 27029; do
   sleep 1 # wait 1 second before check for mongo3t again
 done
 
-exec kytosd -l 192.168.0.3 -f --database mongodb
+tmux new-sess -d -s k1 kytosd -f --database mongodb
+
+touch /var/log/kytos.log
+tail -f /var/log/kytos.log

--- a/data-plane/scripts/tenet_kytos.sh
+++ b/data-plane/scripts/tenet_kytos.sh
@@ -14,4 +14,7 @@ while ! nc -z 192.168.0.8 27029; do
   sleep 1 # wait 1 second before check for mongo3t again
 done
 
-exec kytosd -l 192.168.0.4 -f --database mongodb
+tmux new-sess -d -s k1 kytosd -f --database mongodb
+
+touch /var/log/kytos.log
+tail -f /var/log/kytos.log

--- a/data-plane/sdx_containers/Dockerfile
+++ b/data-plane/sdx_containers/Dockerfile
@@ -8,8 +8,3 @@ WORKDIR /
 RUN git clone https://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@github.com/atlanticwave-sdx/kytos-sdx-topology sdx_topology
 
 RUN for repo in sdx_topology/app; do cd ${repo}; python3 setup.py develop; cd ..; done
-
-RUN echo "192.168.0.6 mongo1t" >> /etc/hosts
-RUN echo "192.168.0.7 mongo2t" >> /etc/hosts
-RUN echo "192.168.0.8 mongo3t" >> /etc/hosts
-


### PR DESCRIPTION
Closes N/A

### Summary

This pull request includes some adjustments to get the SDX environment fully working, such as:

- Change how Kytos-ng is executed in the docker entrypoint script: we cannot use `kytosd -f ...` alone because it requires an interactive terminal to run the console (see more in https://github.com/kytos/kytos/issues/1133). The proposed change is to run kytosd with console in a tmux session and leave a tail on Kytos log
- Add kytos config directory (`etc/kytos`) in order to get the logging working properly with file handler
- Modify the `/etc/hosts` which is not necessary: docker compose includes a DNS service which should take care of name resolution for services
- Fix mininet execution (same error of non-interactive execution as in Kytos). The proposed solution is to run Mininet in a tmux session and leave a `tail -f /dev/null`
- Add Kytos-ng UI download process as part of the docker build (with parameters) to avoid silent failures due to connectivity issues inside the docker container (see more in https://github.com/amlight/kytos-docker/pull/26)
- Add scripts to demonstrate the EVC creation on each domain and dataplane tests
- fixed an issue on:
```
Unknown option 'y'.

Options to the inner command should come after "--", like this:
multipass exec <instance> -- <command> <arguments>
```
- Added option to run non-interactively on debconf and added some `-y` arguments to apt-get to avoid waiting on user input

### Local tests

Here is an execution log to demonstrate the local tests:

```
 ~/g/g> git clone --branch fix/working_env https://github.com/italovalcy/sdx-continuous-development

 ~/g/g>cd sdx-continuous-development

 ~/g/g/sdx-continuous-development> ./0_multipass_setup.sh
Launched: sdx
Mounted '/Users/italo' into 'sdx:Home'
Name                    State             IPv4             Image
sdx                     Running           192.168.64.6     Ubuntu 22.04 LTS
Name:           sdx
State:          Running
IPv4:           192.168.64.6
Release:        Ubuntu 22.04.2 LTS
Image hash:     345fbbb6ec82 (Ubuntu 22.04 LTS)
CPU(s):         4
Load:           0.15 0.24 0.13
Disk usage:     1.7GiB out of 19.2GiB
Memory usage:   193.7MiB out of 3.8GiB
Mounts:         /Users/italo => Home
                    UID map: 501:default
                    GID map: 20:default
### Ubuntu update ###
...
~/g/g/sdx-continuous-development> multipass shell sdx
ubuntu@sdx:~$ cd /sdx/data-plane/
ubuntu@sdx:/sdx/data-plane$ for i in $(seq 1 8); do echo "------------- $i -------------"; bash -x ./${i}_*.sh; done
------------- 1 -------------
+ docker network create --gateway 192.168.0.1 --subnet 192.168.0.0/24 kytos_network
32b585805e99a4778d4933f968a9bd7f247752c68462fccfc1ada81eb8a0e57c
------------- 2 -------------
+ docker build -f ./os_base/debian_base/Dockerfile -t debian_base .
...

ubuntu@sdx:/sdx/data-plane$ docker compose up -d
[+] Running 10/10
 ⠿ Container mongo1t           Started                                                                                                                                                                                                        2.6s
 ⠿ Container mongolc           Started                                                                                                                                                                                                        2.5s
 ⠿ Container mongo2t           Started                                                                                                                                                                                                        2.4s
 ⠿ Container mongo3t           Started                                                                                                                                                                                                        2.7s
 ⠿ Container mongo-rs-init     Started                                                                                                                                                                                                        4.2s
 ⠿ Container mongo-test-ready  Started                                                                                                                                                                                                        5.3s
 ⠿ Container amlight           Started                                                                                                                                                                                                        7.6s
 ⠿ Container sax               Started                                                                                                                                                                                                        7.5s
 ⠿ Container tenet             Started                                                                                                                                                                                                        7.3s
 ⠿ Container mininet           Started                                                                                                                                                                                                        8.3s
ubuntu@sdx:/sdx/data-plane$
ubuntu@sdx:/sdx/data-plane$
ubuntu@sdx:/sdx/data-plane$
ubuntu@sdx:/sdx/data-plane$ docker ps
CONTAINER ID   IMAGE       COMMAND                  CREATED          STATUS          PORTS                                                                                  NAMES
e9d7ae7d6399   mininet     "/start_mininet.sh"      18 seconds ago   Up 9 seconds                                                                                           mininet
9d0082992c7e   sax         "/scripts/sax_kytos.…"   19 seconds ago   Up 10 seconds   0.0.0.0:6654->6653/tcp, :::6654->6653/tcp, 0.0.0.0:8282->8181/tcp, :::8282->8181/tcp   sax
2013b0342cbb   tenet       "/scripts/tenet_kyto…"   19 seconds ago   Up 11 seconds   0.0.0.0:6655->6653/tcp, :::6655->6653/tcp, 0.0.0.0:8383->8181/tcp, :::8383->8181/tcp   tenet
653824a29e26   amlight     "/scripts/amlight_ky…"   19 seconds ago   Up 10 seconds   0.0.0.0:6653->6653/tcp, :::6653->6653/tcp, 0.0.0.0:8181->8181/tcp, :::8181->8181/tcp   amlight
be8943568ba4   sdx_mongo   "/scripts/rs-add.sh"     19 seconds ago   Up 13 seconds   27017/tcp                                                                              mongo-test-ready
9a123a6e3bbd   sdx_mongo   "/scripts/rs-init.sh"    19 seconds ago   Up 14 seconds   27017/tcp                                                                              mongo-rs-init
ed6197875d57   sdx_mongo   "/usr/bin/mongod --b…"   19 seconds ago   Up 16 seconds   27017/tcp, 0.0.0.0:27029->27029/tcp, :::27029->27029/tcp                               mongo3t
1d21f0cef2dc   sdx_mongo   "/usr/bin/mongod --b…"   19 seconds ago   Up 16 seconds   27017/tcp, 0.0.0.0:27030->27030/tcp, :::27030->27030/tcp                               mongolc
2f03199d036a   sdx_mongo   "/usr/bin/mongod --b…"   19 seconds ago   Up 16 seconds   27017/tcp, 0.0.0.0:27027->27027/tcp, :::27027->27027/tcp                               mongo1t
29e54b787459   sdx_mongo   "/usr/bin/mongod --b…"   19 seconds ago   Up 16 seconds   27017/tcp, 0.0.0.0:27028->27028/tcp, :::27028->27028/tcp                               mongo2t
ubuntu@sdx:/sdx/data-plane$ ./scripts/curl/enable_all.sh
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
ubuntu@sdx:/sdx/data-plane$
ubuntu@sdx:/sdx/data-plane$ ./scripts/curl/create_evcs_inter_domain.sh
{"circuit_id":"1ae5bad1212c47"}
{"circuit_id":"81a5d583936648"}
{"circuit_id":"c41b2dfb22e243"}
ubuntu@sdx:/sdx/data-plane$ ./scripts/curl/create_evcs_inter_domain_vlan_translation.sh
{"circuit_id":"5fee77758d5a4c"}
{"circuit_id":"5177a1f273d246"}
{"circuit_id":"1cdeffb7bd354f"}
ubuntu@sdx:/sdx/data-plane$ ./scripts/curl/config_hosts_and_test.sh
PING 10.1.7.8 (10.1.7.8) 56(84) bytes of data.
64 bytes from 10.1.7.8: icmp_seq=1 ttl=64 time=24.5 ms
64 bytes from 10.1.7.8: icmp_seq=2 ttl=64 time=0.388 ms
64 bytes from 10.1.7.8: icmp_seq=3 ttl=64 time=0.483 ms
64 bytes from 10.1.7.8: icmp_seq=4 ttl=64 time=0.596 ms

--- 10.1.7.8 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3040ms
rtt min/avg/max/mdev = 0.388/6.496/24.517/10.404 ms
PING 10.2.1.8 (10.2.1.8) 56(84) bytes of data.
64 bytes from 10.2.1.8: icmp_seq=1 ttl=64 time=11.1 ms
64 bytes from 10.2.1.8: icmp_seq=2 ttl=64 time=0.449 ms
64 bytes from 10.2.1.8: icmp_seq=3 ttl=64 time=0.591 ms
64 bytes from 10.2.1.8: icmp_seq=4 ttl=64 time=0.470 ms

--- 10.2.1.8 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3052ms
rtt min/avg/max/mdev = 0.449/3.170/11.173/4.620 ms
ubuntu@sdx:/sdx/data-plane$
```