### PR TITLE
minor changes to fix issue on the dataplane tests

### DIFF
--- a/0_multipass_setup.sh
+++ b/0_multipass_setup.sh
@@ -44,4 +44,3 @@ multipass mount . sdx:/sdx
 multipass exec sdx -- bash -c "sudo apt-get install python3-pip --assume-yes"
 multipass exec sdx -- bash -c "sudo openssl rand --base64 741 > /sdx/data-plane/os_base/mongo_base/m103-keyfile"
 multipass exec sdx -- bash -c "sudo chmod 400 /sdx/data-plane/os_base/mongo_base/m103-keyfile"
-multipass exec sdx -- bash -c "docker network create --gateway '192.168.0.1' --subnet '192.168.0.0/24' kytos_network"

--- a/data-plane/5_run_all.sh
+++ b/data-plane/5_run_all.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+echo "### Starting services via docker compose ###"
+docker compose up -d
+
+maxWait=180
+echo "### Waiting until services are ready (max wait $maxWait seconds)..."
+while [ $maxWait -gt 0 ]; do
+	if [ $(docker logs amlight 2>/dev/null | grep "HANDSHAKE COMPLETE" | wc -l) -ge 3 ] && [ $(docker logs tenet 2>/dev/null | grep "HANDSHAKE COMPLETE" | wc -l) -ge 3 ] && [ $(docker logs sax 2>/dev/null | grep "HANDSHAKE COMPLETE" | wc -l) -ge 2 ]; then
+		break
+	fi
+	let maxWait--
+	sleep 1
+	if [ $(($maxWait % 10)) -eq 0 ]; then
+		echo "-->" $(date +%F,%X) still waiting...
+	fi
+done
+
+if [ $maxWait -eq 0 ]; then
+	echo ""
+	echo "==> ERROR: Timeout waiting for containers to boot and switches connect. Please check manually"
+	exit 1
+fi
+
+echo "### enable all switches, interfaces, links ###"
+./scripts/curl/enable_all.sh
+
+echo "### create circuits ###"
+echo "---> no vlan translation"
+./scripts/curl/create_evcs_inter_domain.sh
+echo "---> with vlan translation"
+./scripts/curl/create_evcs_inter_domain_vlan_translation.sh
+
+echo "### setup hosts and run data-plate test (ping) ###"
+./scripts/curl/config_hosts_and_test.sh

--- a/data-plane/container-mininet/Dockerfile
+++ b/data-plane/container-mininet/Dockerfile
@@ -1,5 +1,9 @@
 FROM italovalcy/mininet:2.3.0d6
 
+RUN apt-get update && apt-get install -y tmux \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
 USER root
 WORKDIR /root
 

--- a/data-plane/docker-compose.yml
+++ b/data-plane/docker-compose.yml
@@ -231,4 +231,8 @@ services:
 
 networks:
   kytos_network:
-    external: true 
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.0.0/24
+          gateway: 192.168.0.1


### PR DESCRIPTION
Fix #74

### Description of the change

This pull request adds a minor change to the Mininet docker image to make it work on our tests: adds tmux packet.

Other than that, I took the opportunity to make minor improvements:
- Moved the `kytos_network` network definition to the compose file, such that we can create and remove upon starting/stopping services
- Added `data-plane/5_run_all.sh` to include all the scripts that should be executed to test the environment

### Local tests

After running the steps described on the Issue #74, the execution seems to be fine again (showing only relevant steps):

```
ubuntu@sdx:/sdx/data-plane$ ./5_run_all.sh
### Starting services via docker compose ###
[+] Running 13/13
 ⠿ Network data-plane_kytos_network  Created                                                                                                                                                                                                                                                                      0.1s
 ⠿ Container mongolc                 Started                                                                                                                                                                                                                                                                      4.9s
 ⠿ Container rabbitmq                Started                                                                                                                                                                                                                                                                      5.3s
 ⠿ Container mongo3t                 Started                                                                                                                                                                                                                                                                      5.0s
 ⠿ Container mongo2t                 Started                                                                                                                                                                                                                                                                      4.7s
 ⠿ Container mongo1t                 Started                                                                                                                                                                                                                                                                      4.4s
 ⠿ Container sdx-lc                  Started                                                                                                                                                                                                                                                                      4.0s
 ⠿ Container mongo-rs-init           Started                                                                                                                                                                                                                                                                      7.9s
 ⠿ Container mongo-test-ready        Started                                                                                                                                                                                                                                                                      9.8s
 ⠿ Container sax                     Started                                                                                                                                                                                                                                                                     14.5s
 ⠿ Container tenet                   Started                                                                                                                                                                                                                                                                     14.8s
 ⠿ Container amlight                 Started                                                                                                                                                                                                                                                                     14.0s
 ⠿ Container mininet                 Started                                                                                                                                                                                                                                                                     16.6s
### Waiting until services are ready (max wait 180 seconds)...
--> 2023-03-16,09:38:14 still waiting...
--> 2023-03-16,09:38:27 still waiting...
--> 2023-03-16,09:38:40 still waiting...
--> 2023-03-16,09:38:53 still waiting...
--> 2023-03-16,09:39:06 still waiting...
--> 2023-03-16,09:39:19 still waiting...
### enable all switches, interfaces, links ###
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
"Operation successful"
### create circuits ###
---> no vlan translation
{"circuit_id":"82d1705e8e9b4f"}
{"circuit_id":"debe85dca1f340"}
{"circuit_id":"34bf3e9e97ab41"}
---> with vlan translation
{"circuit_id":"cffa1077ab0740"}
{"circuit_id":"25db303b076149"}
{"circuit_id":"db9bdd7b7b0e40"}
### setup hosts and run data-plate test (ping) ###
PING 10.1.7.8 (10.1.7.8) 56(84) bytes of data.
64 bytes from 10.1.7.8: icmp_seq=1 ttl=64 time=37.7 ms
64 bytes from 10.1.7.8: icmp_seq=2 ttl=64 time=0.779 ms
64 bytes from 10.1.7.8: icmp_seq=3 ttl=64 time=0.731 ms
64 bytes from 10.1.7.8: icmp_seq=4 ttl=64 time=0.674 ms

--- 10.1.7.8 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 11ms
rtt min/avg/max/mdev = 0.674/9.969/37.693/16.006 ms
PING 10.2.1.8 (10.2.1.8) 56(84) bytes of data.
64 bytes from 10.2.1.8: icmp_seq=1 ttl=64 time=22.10 ms
64 bytes from 10.2.1.8: icmp_seq=2 ttl=64 time=0.528 ms
64 bytes from 10.2.1.8: icmp_seq=3 ttl=64 time=0.512 ms
64 bytes from 10.2.1.8: icmp_seq=4 ttl=64 time=0.265 ms

--- 10.2.1.8 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 62ms
rtt min/avg/max/mdev = 0.265/6.068/22.968/9.757 ms
```