### PR TITLE
Change kytos base name on data-plane 1_build_kytos.sh script

### DIFF
--- a/data-plane/1_build_kytos.sh
+++ b/data-plane/1_build_kytos.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-docker build -f os_base/kytos_base/Dockerfile -t kytos-base .
+docker build -f os_base/kytos_base/Dockerfile -t kytos_base .
 docker build --no-cache -f container-mininet/Dockerfile -t mininet .
 docker build --no-cache -f os_base/mongo_base/Dockerfile -t sdx-mongo .
 docker build --no-cache -f os_base/python_base/Dockerfile -t python-base .


### PR DESCRIPTION
Closes #82 

### Description of the change

This PR will change the name of the generated image on script `data-plane/1_build_kytos.sh` to match the name expected by `kytos-sdx-topology/Dockerfile` repo.