### PR TITLE
Adjust regex for fix naming convention and add iso_3166 field

### DIFF
--- a/data-plane/container-validator/validator.yml
+++ b/data-plane/container-validator/validator.yml
@@ -49,12 +49,12 @@ paths:
               properties:
                   id:
                     type: string
-                    pattern: '^((urn:sdx:topology:)[A-Za-z_.:-]*$)'
+                    pattern: '^((urn:sdx:topology:)[A-Za-z0-9_.:-]*$)'
                   name:
                     type: string
                     minLength: 3
                     maxLength: 30
-                    pattern: '^[A-Za-z_.-]*$'
+                    pattern: '^[A-Za-z0-9_.-]*$'
                   version:
                     type: integer
                     format: int64
@@ -77,7 +77,7 @@ paths:
                       properties:
                         id:
                           type: string
-                          pattern: '^((urn:sdx:node:)[A-Za-z_.-\:]*$)'
+                          pattern: '^((urn:sdx:node:)[A-Za-z0-9_.\:/-]*$)'
                         name:
                           type: string
                           minLength: 3
@@ -107,12 +107,12 @@ paths:
                       properties:
                         id:
                           type: string
-                          pattern: '^((urn:sdx:link:)[A-Za-z_.-\:]*$)'
+                          pattern: '^((urn:sdx:link:)[A-Za-z0-9_.\:/-]*$)'
                         name:
                           type: string
                           minLength: 3
                           maxLength: 30
-                          pattern: '^[A-Za-z0-9_.-/]*$'
+                          pattern: '^[A-Za-z0-9_./\:-]*$'
                         ports:
                           type: array
                           minItems: 1
@@ -261,21 +261,23 @@ components:
       properties:
         id:
           type: string
-          pattern: '^((urn:sdx:port:)[A-Za-z_.-\:]*$)'
+          pattern: '^((urn:sdx:port:)[A-Za-z0-9_.\:/-]*$)'
         name:
           type: string
           minLength: 3
           maxLength: 30
-          pattern: '^[A-Za-z0-9_.-]*$'
+          pattern: '^[A-Za-z0-9_.\:/-]*$'
         node:
           type: string
-          pattern: '^((urn:sdx:node:)[A-Za-z_.-\:]*$)'
+          pattern: '^((urn:sdx:node:)[A-Za-z0-9_.\:/-]*$)'
         type:
           type: string
           enum: ['100FE','1GE','10GE','25GE','40GE','50GE','100GE','400GE','Other']
         mtu:
           type: integer
           format: int32
+        short_name:
+          type: string
         nni:
           type: string
         status:
@@ -284,6 +286,10 @@ components:
         state:
           type: string
           enum: ['enabled','disabled']
+        label_range:
+          type: array
+          items:
+            type: string
         services:
           items:
               type: object
@@ -316,6 +322,11 @@ components:
           type: number
           minimum: -90.0
           maximum: 90.0
+        iso3166_2_lvl4:
+          type: string
+          minLength: 5
+          maxLength: 5
+          pattern: '^[A-Z]{2}-[A-Z]{2}$'
     ErrorMessage:
       type: object
       required:


### PR DESCRIPTION
Fix #102 

## Description of the change

- Added iso_3166 field into the validation
- Fixed topology ID  regex
- Fixed wrongly usage of the `-` character 
- Enhanced node name and link name to allow more characters 