### PR TITLE
fix issues with requirements and entry point for sdx-controller

### DIFF
--- a/data-plane/docker-compose.yml
+++ b/data-plane/docker-compose.yml
@@ -530,7 +530,7 @@ services:
       SLEEP_TIME: ${SLEEP_TIME}
       DB_NAME: ${SDX_LC_DB_NAME}
       DB_CONFIG_TABLE_NAME: 'sdx-controller'
-    entrypoint: ["python3", "-m", "swagger_server"]
+    entrypoint: ["python3", "-m", "uvicorn", "sdx_controller.app:asgi_app", "--host", "0.0.0.0", "--port", "8080"]
 
 networks:
   kytos_network:

--- a/data-plane/os_base/controller_base/requirements.txt
+++ b/data-plane/os_base/controller_base/requirements.txt
@@ -47,4 +47,4 @@ urllib3==1.26.16
 uvicorn==0.27.1
 werkzeug==2.2.3
 zipp==3.16.2; python_version >= '3.8'
-sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@2.0.3
+sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@2.0.6.dev3


### PR DESCRIPTION
Fix #105 

### Description of the changes

- The requirements were updated according to [upstream requirements](https://github.com/atlanticwave-sdx/sdx-controller/blob/main/pyproject.toml#L34)
- fixed the entry point according to [recommendation from upstream](https://github.com/atlanticwave-sdx/sdx-controller/blob/main/Dockerfile#L24)

### Local tests

After fixing the issues above, the deployment worked better.