### PR TITLE
Removing unnecessary installation of mongodb-shell on kytos-base image

### DIFF
--- a/data-plane/os_base/kytos_base/Dockerfile
+++ b/data-plane/os_base/kytos_base/Dockerfile
@@ -54,14 +54,6 @@ RUN git config --global url."https://github.com".insteadOf git://github.com
 
 WORKDIR /
 
-RUN wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
-RUN apt update
-RUN apt-get install gnupg2
-RUN wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
-RUN echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/5.0 main" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
-RUN apt update
-RUN apt-get install -y mongodb-org-shell
-
 RUN apt install python3-pip --assume-yes
 RUN apt-get purge --assume-yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fix #104 

### Description of the change

The installation of mongodb-shell inside Kytos-base docker image does not seems necessary for the basic functionally of the Kytos container. Besides that, when trying to compile this container for target ARM64 (to run on Apple Silicon, for instance) it fails because mongodb-org-shell package is not available for this architecture (see Issue #104).

### Local tests

After removing this package I executed new tests with full integration with sdx-controller, sdx-lc, etc. and all worked as expected.