### PR TITLE
Adding curl scripts from kytos-sdx-topology Napp

### DIFF
--- a/data-plane/scripts/curl/0.version_control.sh
+++ b/data-plane/scripts/curl/0.version_control.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+TOPOLOGY_API_1="http://0.0.0.0:8181/api/kytos/sdx_topology/v1/version/control"
+TOPOLOGY_API_2="http://0.0.0.0:8181/api/kytos/sdx_topology/v1/version/control"
+TOPOLOGY_API_3="http://0.0.0.0:8181/api/kytos/sdx_topology/v1/version/control"
+echo "##### version control init #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API_1
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API_2
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API_3

--- a/data-plane/scripts/curl/0a.version_control.sh
+++ b/data-plane/scripts/curl/0a.version_control.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/sdx_topology/v1/version/control"
+echo "##### version control init #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API | jq -r .

--- a/data-plane/scripts/curl/0b.version_control.sh
+++ b/data-plane/scripts/curl/0b.version_control.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8282/api/kytos/sdx_topology/v1/version/control"
+echo "##### version control init #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API

--- a/data-plane/scripts/curl/0c.version_control.sh
+++ b/data-plane/scripts/curl/0c.version_control.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8383/api/kytos/sdx_topology/v1/version/control"
+echo "##### version control init #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API

--- a/data-plane/scripts/curl/1a.get_kytos_topology.sh
+++ b/data-plane/scripts/curl/1a.get_kytos_topology.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/topology/v3"
+echo "##### kytos link  topology #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API | jq -r .
+

--- a/data-plane/scripts/curl/1b.get_kytos_topology.sh
+++ b/data-plane/scripts/curl/1b.get_kytos_topology.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+TOPOLOGY_API="http://0.0.0.0:8282/api/kytos/topology/v3"
+echo "##### kytos link  topology #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API | jq -r .

--- a/data-plane/scripts/curl/1c.get_kytos_topology.sh
+++ b/data-plane/scripts/curl/1c.get_kytos_topology.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+TOPOLOGY_API="http://0.0.0.0:8383/api/kytos/topology/v3"
+echo "##### kytos link  topology #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API | jq -r .

--- a/data-plane/scripts/curl/2.enable_all.sh
+++ b/data-plane/scripts/curl/2.enable_all.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+AMLIGHT=http://0.0.0.0:8181
+SAX=http://0.0.0.0:8282
+TENET=http://0.0.0.0:8383
+
+# Enable all switches
+for sw in $(curl -s $AMLIGHT/api/kytos/topology/v3/switches | jq -r '.switches[].id'); do curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/switches/$sw/enable; curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/interfaces/switch/$sw/enable; done
+for sw in $(curl -s $SAX/api/kytos/topology/v3/switches | jq -r '.switches[].id'); do curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/switches/$sw/enable; curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/interfaces/switch/$sw/enable; done
+for sw in $(curl -s $TENET/api/kytos/topology/v3/switches | jq -r '.switches[].id'); do curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/switches/$sw/enable; curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/interfaces/switch/$sw/enable; done
+
+# give a few seconds for link discovery (LLDP)
+sleep 10
+
+# enable all links
+for l in $(curl -s $AMLIGHT/api/kytos/topology/v3/links | jq -r '.links[].id'); do curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/links/$l/enable; done
+for l in $(curl -s $SAX/api/kytos/topology/v3/links | jq -r '.links[].id'); do curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/links/$l/enable; done
+for l in $(curl -s $TENET/api/kytos/topology/v3/links | jq -r '.links[].id'); do curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/links/$l/enable; done
+
+# Amlight network operator role
+curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/switches/aa:00:00:00:00:00:00:01/metadata -d '{"lat": "25.77", "lng": "-80.19", "address": "Miami", "iso3166_2_lvl4": "US-FL"}'
+curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/switches/aa:00:00:00:00:00:00:02/metadata -d '{"lat": "26.38", "lng": "-80.11", "address": "BocaRaton", "iso3166_2_lvl4": "US-FL"}'
+curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/switches/aa:00:00:00:00:00:00:03/metadata -d '{"lat": "30.27", "lng": "-81.68", "address": "Jacksonville", "iso3166_2_lvl4": "US-FL"}'
+curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/interfaces/aa:00:00:00:00:00:00:01:40/metadata -d '{"sdx_nni": "sax.net:Sax01:40"}'
+curl -H 'Content-type: application/json' -X POST $AMLIGHT/api/kytos/topology/v3/interfaces/aa:00:00:00:00:00:00:02:40/metadata -d '{"sdx_nni": "sax.net:Sax02:40"}'
+
+# SAX network operator role
+curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/switches/dd:00:00:00:00:00:00:04/metadata -d '{"lat": "-3", "lng": "-40", "address": "Fortaleza", "iso3166_2_lvl4": "BR-CE"}'
+curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/switches/dd:00:00:00:00:00:00:05/metadata -d '{"lat": "-3", "lng": "-20", "address": "Fortaleza", "iso3166_2_lvl4": "BR-CE"}'
+curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/interfaces/dd:00:00:00:00:00:00:04:40/metadata -d '{"sdx_nni": "ampath.net:Ampath1:40"}'
+curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/interfaces/dd:00:00:00:00:00:00:04:41/metadata -d '{"sdx_nni": "tenet.ac.za:Tenet01:41"}'
+curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/interfaces/dd:00:00:00:00:00:00:05:40/metadata -d '{"sdx_nni": "ampath.net:Ampath2:40"}'
+curl -H 'Content-type: application/json' -X POST $SAX/api/kytos/topology/v3/interfaces/dd:00:00:00:00:00:00:05:41/metadata -d '{"sdx_nni": "tenet.ac.za:Tenet02:41"}'
+
+# TENET operator
+curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/switches/cc:00:00:00:00:00:00:06/metadata -d '{"lat": "-33", "lng": "18", "address": "CapeTown", "iso3166_2_lvl4": "ZA-WC"}'
+curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/switches/cc:00:00:00:00:00:00:07/metadata -d '{"lat": "-26", "lng": "28", "address": "Johanesburgo", "iso3166_2_lvl4": "ZA-GP"}'
+curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/switches/cc:00:00:00:00:00:00:08/metadata -d '{"lat": "-33", "lng": "27", "address": "EastLondon", "iso3166_2_lvl4": "ZA-EC"}'
+curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/interfaces/cc:00:00:00:00:00:00:06:41/metadata -d '{"sdx_nni": "sax.net:Sax01:41"}'
+curl -H 'Content-type: application/json' -X POST $TENET/api/kytos/topology/v3/interfaces/cc:00:00:00:00:00:00:07:41/metadata -d '{"sdx_nni": "sax.net:Sax02:41"}'

--- a/data-plane/scripts/curl/3.create_evcs_inter_domain.sh
+++ b/data-plane/scripts/curl/3.create_evcs_inter_domain.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Creates a circuit between AmLight (h3) and TENET (h8) -- same VLAN all domains
+
+# Amlight domain
+curl -H 'Content-type: application/json' 'http://0.0.0.0:8181/api/kytos/mef_eline/v2/evc/' -d '{"name": "AMLIGHT_vlan_107_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:03:50"}, "uni_z": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:01:40"}}'
+
+# SAX domain
+# curl -H 'Content-type: application/json' 'http://0.0.0.0:8282/api/kytos/mef_eline/v2/evc/' -d '{"name": "SAX_vlan_107_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:04:40"}, "uni_z": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:05:41"}}'
+
+# TENET domain
+# curl -H 'Content-type: application/json' 'http://0.0.0.0:8383/api/kytos/mef_eline/v2/evc/' -d '{"name": "TENET_vlan_107_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:07:41"}, "uni_z": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:08:50"}}'
+

--- a/data-plane/scripts/curl/3a.get_kytos_evc.sh
+++ b/data-plane/scripts/curl/3a.get_kytos_evc.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+EVC_API="http://0.0.0.0:8181/api/kytos/mef_eline/v2/evc"
+echo "##### kytos evc #####"
+curl -H 'Content-Type: application/json' -X GET $EVC_API | jq -r .
+

--- a/data-plane/scripts/curl/4a.shelve_topology.sh
+++ b/data-plane/scripts/curl/4a.shelve_topology.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/sdx_topology/v1/shelve/topology"
+echo "##### shelve topology #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API

--- a/data-plane/scripts/curl/4b.shelve_topology.sh
+++ b/data-plane/scripts/curl/4b.shelve_topology.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8282/api/kytos/sdx_topology/v1/shelve/topology"
+echo "##### shelve topology #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API

--- a/data-plane/scripts/curl/4c.shelve_topology.sh
+++ b/data-plane/scripts/curl/4c.shelve_topology.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8383/api/kytos/sdx_topology/v1/shelve/topology"
+echo "##### shelve topology #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API

--- a/data-plane/scripts/curl/5a.shelve_events.sh
+++ b/data-plane/scripts/curl/5a.shelve_events.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/sdx_topology/v1/shelve/events"
+echo "##### shelve events #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API

--- a/data-plane/scripts/curl/5b.shelve_events.sh
+++ b/data-plane/scripts/curl/5b.shelve_events.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8282/api/kytos/sdx_topology/v1/shelve/events"
+echo "##### shelve events #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API

--- a/data-plane/scripts/curl/5c.shelve_events.sh
+++ b/data-plane/scripts/curl/5c.shelve_events.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8383/api/kytos/sdx_topology/v1/shelve/events"
+echo "##### shelve events #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API

--- a/data-plane/scripts/curl/6a.disable_switch.sh
+++ b/data-plane/scripts/curl/6a.disable_switch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/topology/v3"
+dpid="aa:00:00:00:00:00:00:01"
+# SDX-related variables
+echo "##### disable switch #####"
+curl -H 'Content-Type: application/json' -X POST $TOPOLOGY_API/switches/$dpid/disable -d '$dpid'

--- a/data-plane/scripts/curl/6b.disable_switch.sh
+++ b/data-plane/scripts/curl/6b.disable_switch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8282/api/kytos/topology/v3"
+dpid="dd:00:00:00:00:00:00:05"
+# SDX-related variables
+echo "##### disable switch #####"
+curl -H 'Content-Type: application/json' -X POST $TOPOLOGY_API/switches/$dpid/disable -d '$dpid'

--- a/data-plane/scripts/curl/6c.disable_switch.sh
+++ b/data-plane/scripts/curl/6c.disable_switch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8383/api/kytos/topology/v3"
+dpid="cc:00:00:00:00:00:00:06"
+# SDX-related variables
+echo "##### disable switch #####"
+curl -H 'Content-Type: application/json' -X POST $TOPOLOGY_API/switches/$dpid/disable -d '$dpid'

--- a/data-plane/scripts/curl/7.1validator.sh
+++ b/data-plane/scripts/curl/7.1validator.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+API="http://192.168.0.14:8000/validator/v1/validate"
+echo "##### validate sdx topology #####"
+curl -H "Content-Type: application/json" -X POST $API -d '{}'

--- a/data-plane/scripts/curl/7.2get_validate_sdx_topology.sh
+++ b/data-plane/scripts/curl/7.2get_validate_sdx_topology.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+API="http://0.0.0.0:8181/api/kytos/sdx_topology/v1/validate_sdx_topology"
+echo "##### validate sdx topology #####"
+curl -H "Content-Type: application/json" -X POST $API -d '{}'

--- a/data-plane/scripts/curl/7.3validate_sdx_topology.sh
+++ b/data-plane/scripts/curl/7.3validate_sdx_topology.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+API="http://0.0.0.0:8181/api/kytos/sdx_topology/v1/validate_sdx_topology"
+echo "##### validate sdx topology #####"
+curl -H "Content-Type: application/json" -X POST $API -d '{"sdx_topology":{}}'

--- a/data-plane/scripts/curl/7.4post_sdx_topology.sh
+++ b/data-plane/scripts/curl/7.4post_sdx_topology.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+API="http://0.0.0.0:8181/api/kytos/sdx_topology/v1"
+event_type="0"
+timestamp="None"
+
+echo "##### post sdx topology #####"
+curl -H "Content-Type: application/json" -X GET $API/post_sdx_topology/$event_type/$timestamp

--- a/data-plane/scripts/curl/7.5convert_sdx_topology.sh
+++ b/data-plane/scripts/curl/7.5convert_sdx_topology.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+API="http://0.0.0.0:8181/api/kytos/sdx_topology/v1"
+event_type="0"
+timestamp="None"
+
+echo "##### post sdx topology #####"
+curl -H "Content-Type: application/json" -X GET $API/convert_topology/$event_type/$timestamp

--- a/data-plane/scripts/curl/7.get_validate_sdx_topology.sh
+++ b/data-plane/scripts/curl/7.get_validate_sdx_topology.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/sdx_topology/v1/validate_sdx_topology"
+echo "##### validate sdx topology #####"
+curl -H "Content-Type: application/json" -X POST $TOPOLOGY_API -d '{"sdx_topology":{}}'

--- a/data-plane/scripts/curl/8a.enable_switch.sh
+++ b/data-plane/scripts/curl/8a.enable_switch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/topology/v3"
+dpid="aa:00:00:00:00:00:00:01"
+# SDX-related variables
+echo "##### enable switch #####"
+curl -H 'Content-Type: application/json' -X POST $TOPOLOGY_API/switches/$dpid/enable -d '$dpid'

--- a/data-plane/scripts/curl/8b.enable_switch.sh
+++ b/data-plane/scripts/curl/8b.enable_switch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8282/api/kytos/topology/v3"
+dpid="dd:00:00:00:00:00:00:01"
+# SDX-related variables
+echo "##### enable switch #####"
+curl -H 'Content-Type: application/json' -X POST $TOPOLOGY_API/switches/$dpid/enable -d '$dpid'

--- a/data-plane/scripts/curl/8c.enable_switch.sh
+++ b/data-plane/scripts/curl/8c.enable_switch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8383/api/kytos/topology/v3"
+dpid="cc:00:00:00:00:00:00:01"
+# SDX-related variables
+echo "##### enable switch #####"
+curl -H 'Content-Type: application/json' -X POST $TOPOLOGY_API/switches/$dpid/enable -d '$dpid'

--- a/data-plane/scripts/curl/9.create_evcs_inter_domain.sh
+++ b/data-plane/scripts/curl/9.create_evcs_inter_domain.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Creates a circuit between AmLight (h3) and TENET (h8) -- same VLAN all domains
+
+# Amlight domain
+curl -H 'Content-type: application/json' 'http://0.0.0.0:8181/api/kytos/mef_eline/v2/evc/' -d '{"name": "AMLIGHT_vlan_107_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:03:50"}, "uni_z": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:01:40"}}'
+
+# SAX domain
+curl -H 'Content-type: application/json' 'http://0.0.0.0:8282/api/kytos/mef_eline/v2/evc/' -d '{"name": "SAX_vlan_107_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:04:40"}, "uni_z": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:05:41"}}'
+
+# TENET domain
+curl -H 'Content-type: application/json' 'http://0.0.0.0:8383/api/kytos/mef_eline/v2/evc/' -d '{"name": "TENET_vlan_107_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:07:41"}, "uni_z": {"tag": {"value": 107, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:08:50"}}'

--- a/data-plane/scripts/curl/9a.get_interfaces.sh
+++ b/data-plane/scripts/curl/9a.get_interfaces.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/topology/v3"
+# SDX-related variables
+echo "##### get interfaces #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API/interfaces | jq -r .

--- a/data-plane/scripts/curl/9a.get_links.sh
+++ b/data-plane/scripts/curl/9a.get_links.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/topology/v3"
+# SDX-related variables
+echo "##### get links #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API/links | jq -r .

--- a/data-plane/scripts/curl/9a.get_switches.sh
+++ b/data-plane/scripts/curl/9a.get_switches.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8181/api/kytos/topology/v3"
+# SDX-related variables
+echo "##### get switches #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API/switches | jq -r .

--- a/data-plane/scripts/curl/9b.get_interfaces.sh
+++ b/data-plane/scripts/curl/9b.get_interfaces.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8282/api/kytos/topology/v3"
+# SDX-related variables
+echo "##### get interfaces #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API/interfaces | jq -r .

--- a/data-plane/scripts/curl/9b.get_links.sh
+++ b/data-plane/scripts/curl/9b.get_links.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8282/api/kytos/topology/v3"
+# SDX-related variables
+echo "##### get links #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API/links | jq -r .

--- a/data-plane/scripts/curl/9b.get_switches.sh
+++ b/data-plane/scripts/curl/9b.get_switches.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8282/api/kytos/topology/v3"
+# SDX-related variables
+echo "##### get switches #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API/switches | jq -r .

--- a/data-plane/scripts/curl/9c.get_interfaces.sh
+++ b/data-plane/scripts/curl/9c.get_interfaces.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8383/api/kytos/topology/v3"
+# SDX-related variables
+echo "##### get interfaces #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API/interfaces | jq -r .

--- a/data-plane/scripts/curl/9c.get_links.sh
+++ b/data-plane/scripts/curl/9c.get_links.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8383/api/kytos/topology/v3"
+# SDX-related variables
+echo "##### get links #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API/links | jq -r .

--- a/data-plane/scripts/curl/9c.get_switches.sh
+++ b/data-plane/scripts/curl/9c.get_switches.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+TOPOLOGY_API="http://0.0.0.0:8383/api/kytos/topology/v3"
+# SDX-related variables
+echo "##### get switches #####"
+curl -H 'Content-Type: application/json' -X GET $TOPOLOGY_API/switches | jq -r .

--- a/data-plane/scripts/curl/amlight-sdx-lc.sh
+++ b/data-plane/scripts/curl/amlight-sdx-lc.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cmd="/bin/bash"
+docker exec -it amlight-sdx-lc $cmd

--- a/data-plane/scripts/curl/amlight.sh
+++ b/data-plane/scripts/curl/amlight.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cmd="/bin/bash"
+docker exec -it amlight $cmd

--- a/data-plane/scripts/curl/amlightlog.sh
+++ b/data-plane/scripts/curl/amlightlog.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cmd="tail -f /var/log/kytos.log"
+docker exec -it amlight $cmd

--- a/data-plane/scripts/curl/check_ports.sh
+++ b/data-plane/scripts/curl/check_ports.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+lsof -i -P -n | grep LISTEN
+netstat -tulpn | grep LISTEN
+ss -tulpn | grep LISTEN
+lsof -i:8080
+sudo nmap -sTU -O 192.168.0.2

--- a/data-plane/scripts/curl/config_hosts_and_test.sh
+++ b/data-plane/scripts/curl/config_hosts_and_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# VLAN 107 - same VLAN
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip link add link h8-eth1 name vlan107 type vlan id 107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip link set up vlan107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip addr add 10.1.7.8/24 dev vlan107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip link add link h3-eth1 name vlan107 type vlan id 107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip link set up vlan107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip addr add 10.1.7.3/24 dev vlan107'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ping -c4 10.1.7.8'
+
+# VLAN 201 - VLAN translation
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip link add link h8-eth1 name vlan201 type vlan id 201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip link set up vlan201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h8) ip addr add 10.2.1.8/24 dev vlan201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip link add link h3-eth1 name vlan201 type vlan id 201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip link set up vlan201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ip addr add 10.2.1.3/24 dev vlan201'
+docker exec -it mininet bash -c 'mnexec -a $(pgrep -f -x bash.*mininet:h3) ping -c4 10.2.1.8'

--- a/data-plane/scripts/curl/create_evcs_inter_domain_vlan_translation.sh
+++ b/data-plane/scripts/curl/create_evcs_inter_domain_vlan_translation.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Creates a circuit between AmLight (h3) and TENET (h8) -- using VLAN translation, i.e., endpoints will be VLAN 201, intermediate VLANs will be 202 and 203
+
+# Amlight domain
+curl -H 'Content-type: application/json' 'http://0.0.0.0:8181/api/kytos/mef_eline/v2/evc/' -d '{"name": "AMLIGHT_vlan_201_202_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 201, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:03:50"}, "uni_z": {"tag": {"value": 202, "tag_type": 1}, "interface_id": "aa:00:00:00:00:00:00:01:40"}}'
+
+# SAX domain
+curl -H 'Content-type: application/json' 'http://0.0.0.0:8282/api/kytos/mef_eline/v2/evc/' -d '{"name": "SAX_vlan_202_203_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 202, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:04:40"}, "uni_z": {"tag": {"value": 203, "tag_type": 1}, "interface_id": "dd:00:00:00:00:00:00:05:41"}}'
+
+# TENET domain
+curl -H 'Content-type: application/json' 'http://0.0.0.0:8383/api/kytos/mef_eline/v2/evc/' -d '{"name": "TENET_vlan_201_203_Ampath_Tenet", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 203, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:07:41"}, "uni_z": {"tag": {"value": 201, "tag_type": 1}, "interface_id": "cc:00:00:00:00:00:00:08:50"}}'

--- a/data-plane/scripts/curl/get_global_topology.sh
+++ b/data-plane/scripts/curl/get_global_topology.sh
@@ -1,0 +1,3 @@
+curl -X 'GET' \
+  'http://localhost:8080/SDX-Controller/1.0.0/topology' \
+  -H 'accept: text/plain'

--- a/data-plane/scripts/curl/lc_topology.sh
+++ b/data-plane/scripts/curl/lc_topology.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+echo "### test amlight topology ###"
+SDX_API="http://0.0.0.0:8081/v2/topology"
+curl -vvv -H 'Content-type: application/json' $SDX_API
+echo "### test tenet topology ###"
+SDX_API="http://0.0.0.0:8082/v2/topology"
+curl -vvv -H 'Content-type: application/json' $SDX_API
+echo "### test sax topology ###"
+SDX_API="http://0.0.0.0:8083/v2/topology"
+curl -vvv -H 'Content-type: application/json' $SDX_API
+echo "### test sdx-test topology ###"
+SDX_API="http://0.0.0.0:8084/v2/topology"
+curl -vvv -H 'Content-type: application/json' $SDX_API

--- a/data-plane/scripts/curl/local_topology.sh
+++ b/data-plane/scripts/curl/local_topology.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+SDX_API="http://0.0.0.0:8080/v2/topology"
+
+curl -vvv -H 'Content-type: application/json' $SDX_API

--- a/data-plane/scripts/curl/saxlog.sh
+++ b/data-plane/scripts/curl/saxlog.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cmd="tail -f /var/log/kytos.log"
+docker exec -it sax $cmd

--- a/data-plane/scripts/curl/sdx_controller_test.sh
+++ b/data-plane/scripts/curl/sdx_controller_test.sh
@@ -1,0 +1,24 @@
+curl -X 'POST' \
+  'http://localhost:8080/SDX-Controller/1.0.0/conection' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "id": "test-connection-request",
+    "name": "Test connection request",
+    "start_time": "2000-01-23T04:56:07.000Z",
+    "end_time": "2000-01-23T04:56:07.000Z",
+    "bandwidth_required": 10,
+    "latency_required": 300,
+    "egress_port": {
+        "id": "urn:sdx:port:ampath.net:A1:1",
+        "name": "Novi100:1",
+        "node": "urn:sdx:node:amlight.net:A1",
+        "status": "up"
+    },
+    "ingress_port": {
+        "id": "urn:ogf:network:sdx:port:tenet.ac.za:A1:2",
+        "name": "Novi100:2",
+        "node": "urn:ogf:network:sdx:node:tenet:A1",
+        "status": "up"
+    }
+}'

--- a/data-plane/scripts/curl/tenetlog.sh
+++ b/data-plane/scripts/curl/tenetlog.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cmd="tail -f /var/log/kytos.log"
+docker exec -it tenet $cmd


### PR DESCRIPTION
The curl scripts that used to be hosted on the kytos-sdx-topology () Napp is being migrated to this repo. Scripts will be removed from there (Issue https://github.com/atlanticwave-sdx/kytos-sdx-topology/issues/50).